### PR TITLE
Game window and renderer init

### DIFF
--- a/GameEngine/Game.cpp
+++ b/GameEngine/Game.cpp
@@ -19,6 +19,9 @@ using std::string;
 using std::cout;
 using std::endl;
 
+const int SCREEN_WIDTH = 1200;
+const int SCREEN_HEIGHT = 800;
+
 const float PLAYER_MOVEMENT_SPEED = 0.5f;
 const float CAMERA_MOVEMENT_SPEED = 0.3f;
 
@@ -34,9 +37,8 @@ public:
 ControlInput controlInput;
 ControlInput cameraControlInput;
 
-Game::Game(SDL_Window* window) {
-	_window = window;
-	_renderer = SDL_CreateRenderer(_window, -1, 0);
+Game::Game() {
+	SDL_CreateWindowAndRenderer(SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_SHOWN, &_window, &_renderer);
 	SDL_SetRenderDrawColor(_renderer, 255, 255, 255, 255);
 
 	_sceneManager = new SceneManager();

--- a/GameEngine/Game.cpp
+++ b/GameEngine/Game.cpp
@@ -19,9 +19,6 @@ using std::string;
 using std::cout;
 using std::endl;
 
-const int SCREEN_WIDTH = 1200;
-const int SCREEN_HEIGHT = 800;
-
 const float PLAYER_MOVEMENT_SPEED = 0.5f;
 const float CAMERA_MOVEMENT_SPEED = 0.3f;
 
@@ -37,13 +34,14 @@ public:
 ControlInput controlInput;
 ControlInput cameraControlInput;
 
-Game::Game() {
-	SDL_CreateWindowAndRenderer(SCREEN_WIDTH, SCREEN_HEIGHT, SDL_WINDOW_SHOWN, &_window, &_renderer);
+Game::Game(SDL_Window* window, SDL_Renderer* renderer) {
+	_window = window;
+	_renderer = renderer;
+
 	SDL_SetRenderDrawColor(_renderer, 255, 255, 255, 255);
 
 	_sceneManager = new SceneManager();
 
-	_running = true;
 	Init();
 }
 
@@ -108,7 +106,7 @@ void Game::Input() {
 
 		// Quit
 		if (keyboard_state[SDL_SCANCODE_ESCAPE]) {
-			_running = false;
+			running = false;
 		}
 	}
 

--- a/GameEngine/Game.h
+++ b/GameEngine/Game.h
@@ -6,7 +6,7 @@
 class Game
 {
 public:
-	Game(SDL_Window* window);
+	Game();
 	~Game();
 
 	/**

--- a/GameEngine/Game.h
+++ b/GameEngine/Game.h
@@ -6,7 +6,7 @@
 class Game
 {
 public:
-	Game();
+	Game(SDL_Window* SDL_window, SDL_Renderer* renderer);
 	~Game();
 
 	/**
@@ -26,7 +26,7 @@ public:
 	*/
 	void Render();
 
-	bool _running;
+	bool running = true;
 
 private:
 	SDL_Window* _window;

--- a/GameEngine/Main.cpp
+++ b/GameEngine/Main.cpp
@@ -13,7 +13,10 @@ int main(int argc, char* args[]) {
 	SDL_Init(SDL_INIT_EVERYTHING);
 	SDL_Window* window;
 	SDL_Renderer* renderer;
-	SDL_CreateWindowAndRenderer(1200, 800, SDL_WINDOW_SHOWN, &window, &renderer);
+	if (SDL_CreateWindowAndRenderer(1200, 800, SDL_WINDOW_SHOWN, &window, &renderer)) {
+		SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Couldn't create window and renderer: %s", SDL_GetError());
+		return 3;
+	}
 	Game* game = new Game(window, renderer);
 
 	while (game->running) {

--- a/GameEngine/Main.cpp
+++ b/GameEngine/Main.cpp
@@ -8,8 +8,7 @@ int main(int argc, char* args[]) {
 	Uint32 last_step = SDL_GetTicks();
 
 	SDL_Init(SDL_INIT_EVERYTHING);
-	SDL_Window* window = SDL_CreateWindow("Title", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 928, 793, SDL_WINDOW_SHOWN);
-	Game* game = new Game(window);
+	Game* game = new Game();
 
 	while (game->_running) {
 		Uint32 current_step = SDL_GetTicks();

--- a/GameEngine/Main.cpp
+++ b/GameEngine/Main.cpp
@@ -2,15 +2,21 @@
 #include <SDL.h>
 #include "Game.h"
 
+const int SCREEN_WIDTH = 1200;
+const int SCREEN_HEIGHT = 800;
+
 int main(int argc, char* args[]) {
 	const Uint32 MIN_FPS = 6;
 	Uint32 min_delta_time = 1000 / MIN_FPS;
 	Uint32 last_step = SDL_GetTicks();
 
 	SDL_Init(SDL_INIT_EVERYTHING);
-	Game* game = new Game();
+	SDL_Window* window;
+	SDL_Renderer* renderer;
+	SDL_CreateWindowAndRenderer(1200, 800, SDL_WINDOW_SHOWN, &window, &renderer);
+	Game* game = new Game(window, renderer);
 
-	while (game->_running) {
+	while (game->running) {
 		Uint32 current_step = SDL_GetTicks();
 
 		if (last_step < current_step) {


### PR DESCRIPTION
Simplify initialization by using SDL 2.0 function SDL_CreateWindowAndRenderer. No reason in this case to have the initialization decoupled.

Also includes error checking to ensure SDL_CreateWindowAndRenderer is successful before starting the game loop.