### PR TITLE
GUI scenes hierachy

### DIFF
--- a/GameEngine/GameEngine.cpp
+++ b/GameEngine/GameEngine.cpp
@@ -101,7 +101,6 @@ void GameEngine::Update(Uint32 deltaTime) {
 		GameGUI::ShowEditorMainMenuBar(this);
 		GameGUI::ShowEditorGameControlBar(this);
 		GameGUI::ShowEditorSceneHierachy(&sceneManager);
-		GameGUI::ShowEditorEntityList(currentScene);
 		GameGUI::ShowEditorEntityProperties();
 
 		ImGui::ShowDemoWindow();

--- a/GameEngine/GameEngine.cpp
+++ b/GameEngine/GameEngine.cpp
@@ -100,6 +100,7 @@ void GameEngine::Update(Uint32 deltaTime) {
 
 		GameGUI::ShowEditorMainMenuBar(this);
 		GameGUI::ShowEditorGameControlBar(this);
+		GameGUI::ShowEditorSceneHierachy(&sceneManager);
 		GameGUI::ShowEditorEntityList(currentScene);
 		GameGUI::ShowEditorEntityProperties();
 

--- a/GameEngine/GameGUI.cpp
+++ b/GameEngine/GameGUI.cpp
@@ -62,6 +62,21 @@ void GameGUI::ShowEditorGameControlBar(GameEngine* gameEngine)
     ImGui::End();
 }
 
+void GameGUI::ShowEditorSceneHierachy(SceneManager* sceneManager)
+{
+    if (ImGui::Begin("Scene Hierachy")) {
+        for (Scene* scene : sceneManager->_scenes) {
+            if (ImGui::TreeNode(scene->name.c_str())) {
+                for (Entity* entity : scene->entities) {
+                    ImGui::TreeNodeEx(entity->GetComponent<NameComponent>()->_name.c_str(), ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen);
+                }
+                ImGui::TreePop();
+            }
+        }
+        ImGui::End();
+    }
+}
+
 void GameGUI::ShowEditorEntityList(Scene* currentScene)
 {
     if (ImGui::Begin("Entities")) {

--- a/GameEngine/GameGUI.cpp
+++ b/GameEngine/GameGUI.cpp
@@ -69,34 +69,15 @@ void GameGUI::ShowEditorSceneHierachy(SceneManager* sceneManager)
             if (ImGui::TreeNode(scene->name.c_str())) {
                 for (Entity* entity : scene->entities) {
                     ImGui::TreeNodeEx(entity->GetComponent<NameComponent>()->_name.c_str(), ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen);
+                    if (ImGui::IsItemClicked()) {
+                        selectedEntity = entity;
+                    }
                 }
                 ImGui::TreePop();
             }
-        }
-        ImGui::End();
-    }
-}
-
-void GameGUI::ShowEditorEntityList(Scene* currentScene)
-{
-    if (ImGui::Begin("Entities")) {
-        if (ImGui::ListBoxHeader("Entities"))
-        {
-            for (Entity* entity : currentScene->entities)
-            {
-                string entityName = to_string(entity->_id);
-                if (entity->GetComponent<NameComponent>()) {
-                    entityName += " \"" + entity->GetComponent<NameComponent>()->_name + "\"";
-                }
-                bool isSelected = selectedEntity == entity;
-                if (ImGui::Selectable(entityName.c_str(), isSelected))
-                {
-                    selectedEntity = entity;
-                }
-                if (isSelected)
-                    ImGui::SetItemDefaultFocus();
+            if (ImGui::IsItemClicked()) {
+                sceneManager->SetScene(sceneManager->GetSceneNumber(scene));
             }
-            ImGui::ListBoxFooter();
         }
         ImGui::End();
     }

--- a/GameEngine/GameGUI.h
+++ b/GameEngine/GameGUI.h
@@ -12,6 +12,8 @@ public:
 
     static void ShowEditorGameControlBar(GameEngine* gameEngine);
 
+    static void ShowEditorSceneHierachy(SceneManager* sceneManager);
+
     static void ShowEditorEntityList(Scene* currentScene);
 
     static void ShowEditorEntityProperties();

--- a/GameEngine/GameGUI.h
+++ b/GameEngine/GameGUI.h
@@ -14,8 +14,6 @@ public:
 
     static void ShowEditorSceneHierachy(SceneManager* sceneManager);
 
-    static void ShowEditorEntityList(Scene* currentScene);
-
     static void ShowEditorEntityProperties();
 
     static void ShowEditorEntityPropertiesID();

--- a/GameEngine/Scene.h
+++ b/GameEngine/Scene.h
@@ -34,6 +34,8 @@ public:
 	void Update();
 	void Render();
 
+	string name = "UnnamedScene";
+
 	std::vector<Entity*> entities;
 private:
 	RenderSystem* _renderSystem;

--- a/GameEngine/SceneManager.cpp
+++ b/GameEngine/SceneManager.cpp
@@ -15,6 +15,7 @@ SceneManager::~SceneManager()
 void SceneManager::AddScene(Scene* scene, string sceneFilename)
 {
 	scene->AddEntitiesFromJSON(sceneFilename);
+	scene->name = sceneFilename;
 	_scenes.push_back(scene);
 }
 

--- a/GameEngine/SceneManager.cpp
+++ b/GameEngine/SceneManager.cpp
@@ -39,6 +39,16 @@ int SceneManager::GetCurrentSceneNumber()
 	return _currentScene;
 }
 
+int SceneManager::GetSceneNumber(Scene* scene)
+{
+	auto it = std::find(_scenes.begin(), _scenes.end(), scene);
+
+	if (it != _scenes.end())
+		return (it - _scenes.begin());
+	else 
+		return -1;
+}
+
 void SceneManager::Update()
 {
 	GetCurrentScene()->Update();

--- a/GameEngine/SceneManager.h
+++ b/GameEngine/SceneManager.h
@@ -13,6 +13,7 @@ public:
 	Scene* GetScene(int sceneNumber);
 	void SetScene(int sceneNumber);
 	int GetCurrentSceneNumber();
+	int GetSceneNumber(Scene* scene);
 
 	void Update();
 	void Render();

--- a/GameEngine/SceneManager.h
+++ b/GameEngine/SceneManager.h
@@ -17,7 +17,8 @@ public:
 	void Update();
 	void Render();
 
+	std::vector<Scene*> _scenes;
+
 private:
 	int _currentScene = 0;
-	std::vector<Scene*> _scenes;
 };

--- a/GameEngine/imgui.ini
+++ b/GameEngine/imgui.ini
@@ -4,9 +4,9 @@ Size=400,400
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-Pos=1032,34
+Pos=1051,38
 Size=550,578
-Collapsed=0
+Collapsed=1
 
 [Window][Hello, world!]
 Pos=12,34
@@ -14,8 +14,8 @@ Size=339,134
 Collapsed=0
 
 [Window][Entity properties]
-Pos=1600,310
-Size=320,737
+Pos=1600,401
+Size=320,646
 Collapsed=0
 
 [Window][General]
@@ -49,8 +49,8 @@ Size=320,1002
 Collapsed=0
 
 [Window][Scene Hierachy]
-Pos=1601,38
-Size=319,273
+Pos=1600,38
+Size=319,364
 Collapsed=0
 
 [Table][0xA43C3885,3]

--- a/GameEngine/imgui.ini
+++ b/GameEngine/imgui.ini
@@ -4,9 +4,9 @@ Size=400,400
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-Pos=1052,38
+Pos=1032,34
 Size=550,578
-Collapsed=1
+Collapsed=0
 
 [Window][Hello, world!]
 Pos=12,34
@@ -24,7 +24,7 @@ Size=339,153
 Collapsed=0
 
 [Window][Entities]
-Pos=1600,37
+Pos=197,537
 Size=320,273
 Collapsed=0
 
@@ -46,6 +46,11 @@ Collapsed=0
 [Window][##SideBar]
 Pos=1600,38
 Size=320,1002
+Collapsed=0
+
+[Window][Scene Hierachy]
+Pos=1601,38
+Size=319,273
 Collapsed=0
 
 [Table][0xA43C3885,3]
@@ -141,4 +146,9 @@ Column 2  Width=-1
 Column 3  Weight=1.0000
 Column 4  Weight=1.0000
 Column 5  Weight=-1.0000
+
+[Table][0xE0773582,3]
+Column 0  Weight=1.0000
+Column 1  Weight=1.0000
+Column 2  Weight=1.0000
 


### PR DESCRIPTION
Replace entity list in engine editor GUI with scene manager which includes all scenes and all entities within those scenes.
Selecting an entity still opens the properties panel.
Selecting a scene now changes the actual scene being _(input/updated/)_ rendered.